### PR TITLE
fix insecure error in the recent-entry plugin using DiaryContainer

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2017-12-27 TADA Tadashi <t@tdtds.jp>
+	* fix insecure error in the recent-entry plugin using DiaryContainer
+
 2017-09-29 TADA Tadashi <t@tdtds.jp>
 	* release 5.0.6
 

--- a/plugin/recent-entry.rb
+++ b/plugin/recent-entry.rb
@@ -7,6 +7,7 @@
 # Copyright (c) 2001,2002 Junichiro KITA <kita@kitaj.no-ip.com>
 # You can redistribute it and/or modify it under GPL.
 #
+require 'tdiary/diary_container'
 
 def recent_entry(max = 5, limit = 20)
 	max = max.to_i


### PR DESCRIPTION
fix #17

tdiary/tdiary-core#656 と同様の修正をrecent-entryプラグインにも適用。