### PR TITLE
Add release workflow with trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
       run: |
         sudo apt-get update && sudo apt-get -y install libidn11-dev
         echo 'gemspec' > Gemfile.local
-        gem update bundler --no-document
         bundle install --jobs=3 --retry=3
     - name: Run test
       run: bundle exec rake spec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,10 @@ jobs:
         ruby: [ '3.3', '3.2', '3.1', '3.0' ]
         test_mode: [ rack, gem ]
     runs-on: ubuntu-latest
+    env:
+      BUNDLE_WITHOUT: server
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -22,7 +24,7 @@ jobs:
         sudo apt-get update && sudo apt-get -y install libidn11-dev
         echo 'gemspec' > Gemfile.local
         gem update bundler --no-document
-        bundle install --without server --jobs=3 --retry=3
+        bundle install --jobs=3 --retry=3
     - name: Run test
       run: bundle exec rake spec
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  push:
+    name: Push gem to RubyGems.org
+    if: github.repository == 'tdiary/tdiary-blogkit'
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+      id-token: write
+    env:
+      # Building and pushing the gem needs no dev/test gems.
+      BUNDLE_WITHOUT: development:test
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.4'
+        bundler-cache: true
+    - name: Publish to RubyGems.org
+      uses: rubygems/release-gem@v1
+    - name: Create GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        case "$GITHUB_REF_NAME" in
+          *beta*|*rc*) PRERELEASE=--prerelease ;;
+        esac
+        gh release create "$GITHUB_REF_NAME" --title "tdiary-blogkit ${GITHUB_REF_NAME#v}" --generate-notes --verify-tag $PRERELEASE


### PR DESCRIPTION
Pushing a `v*` tag now publishes the gem to RubyGems.org via `rubygems/release-gem@v1` (trusted publishing) and creates a GitHub Release with `gh release create --generate-notes --verify-tag` (`--prerelease` for beta/rc tags). Same structure as tdiary-core's `release.yml`, minus the tarball packaging job.

Before merging, two setup steps are required:

1. On rubygems.org, configure a trusted publisher for the `tdiary-blogkit` gem: GitHub Actions publisher with repository `tdiary/tdiary-blogkit`, workflow `release.yml`, environment `release`.
2. On this GitHub repository, create the `release` environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)